### PR TITLE
Fix how to import for shaking size down when bundled

### DIFF
--- a/src/PasswordField.js
+++ b/src/PasswordField.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { TextField } from 'material-ui';
+import TextField from 'material-ui/TextField';
 import Show from 'material-ui/svg-icons/action/visibility';
 import Hide from 'material-ui/svg-icons/action/visibility-off';
 


### PR DESCRIPTION
`import X from 'material-ui/x'` is preferrable than `import { X } from 'material-ui'`.
This shakes down file size when bundled.
http://www.material-ui.com/#/get-started/usage