### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   },
   "homepage": "https://github.com/miya0001/password-field#readme",
   "dependencies": {
-    "material-ui": "^0.20.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "material-ui": "^0.20.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -32,6 +34,8 @@
     "chai": "^4.1.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-scripts": "^1.1.1",
     "sinon": "^4.3.0"
   }


### PR DESCRIPTION
`peerDependencies` explicits which React version dependencies.
https://docs.npmjs.com/files/package.json#peerdependencies

`npm install` dispalys warning when users try to install PasswordField with not-tested React versions.